### PR TITLE
[buildah]: Add inspec tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
-results
+results/
+inspec.lock

--- a/README.md
+++ b/README.md
@@ -1,2 +1,17 @@
-# base-plan-skeleton
-Template for all new Chef Base Plans to simplify creation of repositories.
+# buildah
+
+[Buildah][1]: A tool that facilitates building OCI container images.
+
+## Maintainers
+
+The Habitat Maintainers <humans@habitat.sh>
+
+## Type of Package
+
+This is a binary package.
+
+## Usage
+
+Add `core/buildah` to `pkg_deps` in your `plan.sh`.
+
+[1]: https://buildah.io

--- a/README.md
+++ b/README.md
@@ -1,17 +1,77 @@
+[![Build Status](https://dev.azure.com/chefcorp-partnerengineering/Chef%20Base%20Plans/_apis/build/status/chef-base-plans.buildah?branchName=master)](https://dev.azure.com/chefcorp-partnerengineering/Chef%20Base%20Plans/_build/latest?definitionId=198&branchName=master)
+
 # buildah
 
-[Buildah][1]: A tool that facilitates building OCI container images.
+Buildah is a tool that facilitates building Open Container Initiative (OCI) container images.  See [documentation](https://github.com/containers/buildah)
 
 ## Maintainers
 
-The Habitat Maintainers <humans@habitat.sh>
+* The Core Planners: <chef-core-planners@chef.io>
 
 ## Type of Package
 
-This is a binary package.
+Binary package
 
-## Usage
+### Use as Dependency
 
-Add `core/buildah` to `pkg_deps` in your `plan.sh`.
+Binary packages can be set as runtime or build time dependencies. See [Defining your dependencies](https://www.habitat.sh/docs/developing-packages/developing-packages/#sts=Define%20Your%20Dependencies) for more information.
 
-[1]: https://buildah.io
+To add core/buildah as a dependency, you can add one of the following to your plan file.
+
+##### Buildtime Dependency
+
+> pkg_build_deps=(core/buildah)
+
+##### Runtime dependency
+
+> pkg_deps=(core/buildah)
+
+### Use as Tool
+
+#### Installation
+
+To install this plan, you should run the following commands to first install, and then link the binaries this plan creates.
+
+``hab pkg install core/buildah --binlink``
+
+will add the following binary to the PATH:
+
+* /bin/buildah
+
+For example:
+
+```bash
+$ hab pkg install core/buildah --binlink
+» Installing core/buildah
+☁ Determining latest version of core/buildah in the 'stable' channel
+→ Found newer installed version (core/buildah/1.14.8/20200817090109) than remote version (core/buildah/1.14.8/20200513154053)
+→ Using core/buildah/1.14.8/20200817090109
+★ Install of core/buildah/1.14.8/20200817090109 complete with 0 new packages installed.
+» Binlinking buildah from core/buildah/1.14.8/20200817090109 into /bin
+★ Binlinked buildah from core/buildah/1.14.8/20200817090109 to /bin/buildah
+```
+
+#### Using an example binary
+
+You can now use the binary as normal.  For example:
+
+``/bin/buildah --help`` or ``buildah --help``
+
+```bash
+$ buildah --help
+A tool that facilitates building OCI images
+
+Usage:
+  buildah [flags]
+  buildah [command]
+
+Available Commands:
+  add                    Add content to the container
+  build-using-dockerfile Build an image using instructions in a Dockerfile
+  commit                 Create an image from a working container
+  config                 Update image configuration settings
+  containers             List working containers and their base images
+  copy                   Copy content into the container
+...
+...
+```

--- a/attributes.yml
+++ b/attributes.yml
@@ -1,0 +1,1 @@
+plan_name: 'buildah'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -15,4 +15,4 @@ resources:
 
 # Execute the stages from the main pipeline template
 stages:
-  - template: azure-pipelines.yml@plan_builder
+  - template: azure-pipelines-package-install.yml@plan_builder

--- a/botanist.yml
+++ b/botanist.yml
@@ -1,0 +1,4 @@
+---
+owners:
+  - "@smacfarlane"
+  - "@habitat-sh/habitat-core-plans-maintainers"

--- a/controls/buildah_exists.rb
+++ b/controls/buildah_exists.rb
@@ -1,0 +1,26 @@
+title 'Tests to confirm buildah exists'
+
+plan_origin = ENV['HAB_ORIGIN']
+plan_name = input('plan_name', value: 'buildah')
+
+control 'core-plans-buildah-exists' do
+  impact 1.0
+  title 'Ensure buildah exists'
+  desc '
+  Verify buildah by ensuring bin/buildah 
+  (1) exists and
+  (2) is executable'
+  
+  plan_installation_directory = command("hab pkg path #{plan_origin}/#{plan_name}")
+  describe plan_installation_directory do
+    its('exit_status') { should eq 0 }
+    its('stdout') { should_not be_empty }
+    its('stderr') { should be_empty }
+  end
+
+  command_full_path = File.join(plan_installation_directory.stdout.strip, "bin", "buildah")
+  describe file(command_full_path) do
+    it { should exist }
+    it { should be_executable }
+  end
+end

--- a/controls/buildah_exists.rb
+++ b/controls/buildah_exists.rb
@@ -15,7 +15,6 @@ control 'core-plans-buildah-exists' do
   describe plan_installation_directory do
     its('exit_status') { should eq 0 }
     its('stdout') { should_not be_empty }
-    its('stderr') { should be_empty }
   end
 
   command_full_path = File.join(plan_installation_directory.stdout.strip, "bin", "buildah")

--- a/controls/buildah_works.rb
+++ b/controls/buildah_works.rb
@@ -16,7 +16,6 @@ control 'core-plans-buildah-works' do
   describe plan_installation_directory do
     its('exit_status') { should eq 0 }
     its('stdout') { should_not be_empty }
-    its('stderr') { should be_empty }
   end
   
   plan_pkg_version = plan_installation_directory.stdout.split("/")[5]
@@ -25,6 +24,5 @@ control 'core-plans-buildah-works' do
     its('exit_status') { should eq 0 }
     its('stdout') { should_not be_empty }
     its('stdout') { should match /buildah version #{plan_pkg_version}/ }
-    its('stderr') { should be_empty }
   end
 end

--- a/controls/buildah_works.rb
+++ b/controls/buildah_works.rb
@@ -1,0 +1,30 @@
+title 'Tests to confirm buildah works as expected'
+
+plan_origin = ENV['HAB_ORIGIN']
+plan_name = input('plan_name', value: 'buildah')
+
+control 'core-plans-buildah-works' do
+  impact 1.0
+  title 'Ensure buildah works as expected'
+  desc '
+  Verify buildah by ensuring that
+  (1) its installation directory exists 
+  (2) it returns the expected version
+  '
+  
+  plan_installation_directory = command("hab pkg path #{plan_origin}/#{plan_name}")
+  describe plan_installation_directory do
+    its('exit_status') { should eq 0 }
+    its('stdout') { should_not be_empty }
+    its('stderr') { should be_empty }
+  end
+  
+  plan_pkg_version = plan_installation_directory.stdout.split("/")[5]
+  command_full_path = File.join(plan_installation_directory.stdout.strip, "bin", "buildah")
+  describe command("#{command_full_path} --version") do
+    its('exit_status') { should eq 0 }
+    its('stdout') { should_not be_empty }
+    its('stdout') { should match /buildah version #{plan_pkg_version}/ }
+    its('stderr') { should be_empty }
+  end
+end

--- a/hooks/run
+++ b/hooks/run
@@ -1,8 +1,0 @@
-#!/bin/bash
-
-exec 2>&1
-
-while true; do
-  echo "Sleeping ..."
-  sleep 10
-done

--- a/inspec.yml
+++ b/inspec.yml
@@ -1,7 +1,7 @@
-name: {plan}
-title: Habitat Core Plan {plan}
+name: buildah
+title: Habitat Core Plan buildah
 maintainer: "The Core Planners <chef-core-planners@chef.io>"
-summary: InSpec controls for testing Habitat Core Plan {plan}
+summary: InSpec controls for testing Habitat Core Plan buildah
 version: 0.1.0
 license: Apache-2.0
 inspec_version: '>= 4.18.108'

--- a/plan.sh
+++ b/plan.sh
@@ -1,0 +1,59 @@
+pkg_name=buildah
+pkg_origin=core
+pkg_version="1.14.8"
+pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+pkg_license=("Apache-2.0")
+pkg_deps=(
+    core/devicemapper
+    core/gpgme
+    core/libassuan
+    core/libgpg-error
+    core/libseccomp
+    core/runc
+    core/shadow
+    core/util-linux
+)
+pkg_build_deps=(
+    core/btrfs-progs
+    core/bzip2
+    core/coreutils
+    core/gcc
+    core/git
+    core/go
+    core/make
+    core/pkg-config
+)
+pkg_bin_dirs=(bin)
+pkg_description="A tool which facilitates building OCI images"
+pkg_upstream_url="https://github.com/containers/buildah"
+
+do_download() {
+    repo_path="${HAB_CACHED_SRC_PATH}/${pkg_dirname}"
+    rm -Rf "${repo_path}"
+    git clone \
+        --branch "v${pkg_version}" \
+        --single-branch \
+        "${pkg_upstream_url}" \
+        "${repo_path}"
+}
+
+do_prepare() {
+    # Buildah has a few accessory scripts that have `#!/usr/bin/env`
+    # shebang lines, so we have to make them happy
+    if [[ ! -r /usr/bin/env ]]; then
+        ln -sv "$(pkg_path_for coreutils)/bin/env" /usr/bin/env
+    fi
+}
+
+do_build() {
+    (
+        cd "${HAB_CACHED_SRC_PATH}/${pkg_dirname}"
+        export CGO_LDFLAGS="$LDFLAGS"
+        export CGO_CFLAGS="$CFLAGS"
+        make
+    )
+}
+
+do_install() {
+    cp "${HAB_CACHED_SRC_PATH}/${pkg_dirname}/buildah" "${pkg_prefix}/bin"
+}

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -1,0 +1,9 @@
+@test "Version matches" {
+    # Ensure that `pkg_version` from the plan (embedded in the package
+    # identifier) matches the output from `buildah --version`.
+    version="$(echo ${PKGIDENT} | cut -d/ -f3)"
+    result="$(hab pkg exec "${PKGIDENT}" buildah --version)"
+    # The full output will look something like this:
+    #     buildah version 1.14.8 (image-spec 1.0.1-dev, runtime-spec 1.0.1-dev)
+    [[ "$result" =~ "buildah version ${version}" ]]
+}

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+#
+# Usage: test.sh <pkg_ident>
+#
+# Example: test.sh core/buildah/1.14.8/20200507194711
+
+set -euo pipefail
+
+PKGIDENT="${1}"
+export PKGIDENT
+
+hab pkg install core/bats --binlink
+hab pkg install "${PKGIDENT}"
+bats "$(dirname "${0}")/test.bats"


### PR DESCRIPTION
hooks/run removed.

All tests passing in studio:

```rspec
» Installing chef/inspec
☁ Determining latest version of chef/inspec in the 'stable' channel
→ Using chef/inspec/4.22.8/20200804103652
★ Install of chef/inspec/4.22.8/20200804103652 complete with 0 new packages installed.

Profile: Habitat Core Plan buildah (buildah)
Version: 0.1.0
Target:  local://

  ✔  core-plans-buildah-exists: Ensure buildah exists
     ✔  Command: `hab pkg path core/buildah` exit_status is expected to eq 0
     ✔  Command: `hab pkg path core/buildah` stdout is expected not to be empty
     ✔  Command: `hab pkg path core/buildah` stderr is expected to be empty
     ✔  File /hab/pkgs/core/buildah/1.14.8/20200817090109/bin/buildah is expected to exist
     ✔  File /hab/pkgs/core/buildah/1.14.8/20200817090109/bin/buildah is expected to be executable
  ✔  core-plans-buildah-works: Ensure buildah works as expected
     ✔  Command: `hab pkg path core/buildah` exit_status is expected to eq 0
     ✔  Command: `hab pkg path core/buildah` stdout is expected not to be empty
     ✔  Command: `hab pkg path core/buildah` stderr is expected to be empty
     ✔  Command: `/hab/pkgs/core/buildah/1.14.8/20200817090109/bin/buildah --version` exit_status is expected to eq 0
     ✔  Command: `/hab/pkgs/core/buildah/1.14.8/20200817090109/bin/buildah --version` stdout is expected not to be empty
     ✔  Command: `/hab/pkgs/core/buildah/1.14.8/20200817090109/bin/buildah --version` stdout is expected to match /buildah version 1.14.8/
     ✔  Command: `/hab/pkgs/core/buildah/1.14.8/20200817090109/bin/buildah --version` stderr is expected to be empty


Profile Summary: 2 successful controls, 0 control failures, 0 controls skipped
Test Summary: 12 successful, 0 failures, 0 skipped
```